### PR TITLE
Wire InstructionTracer into breakpoint and memcheck paths

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -785,8 +785,10 @@ endif()
 
 # DebugTools sources
 set(pcsx2DebugToolsSources
-	DebugTools/DebugInterface.cpp
-	DebugTools/DisassemblyManager.cpp
+    DebugTools/DebugInterface.cpp
+    DebugTools/InstructionTracer.cpp
+    DebugTools/MemoryScanner.cpp
+    DebugTools/DisassemblyManager.cpp
 	DebugTools/ExpressionParser.cpp
 	DebugTools/MIPSAnalyst.cpp
 	DebugTools/MipsAssembler.cpp
@@ -803,8 +805,10 @@ set(pcsx2DebugToolsSources
 
 # DebugTools headers
 set(pcsx2DebugToolsHeaders
-	DebugTools/DebugInterface.h
-	DebugTools/DisassemblyManager.h
+    DebugTools/DebugInterface.h
+    DebugTools/InstructionTracer.h
+    DebugTools/MemoryScanner.h
+    DebugTools/DisassemblyManager.h
 	DebugTools/ExpressionParser.h
 	DebugTools/MIPSAnalyst.h
 	DebugTools/MipsAssembler.h

--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "Breakpoints.h"
+#include "MemoryScanner.h"
+#include "InstructionTracer.h"
 #include "SymbolGuardian.h"
 #include "MIPSAnalyst.h"
 #include <cstdio>
@@ -18,6 +20,31 @@ std::vector<MemCheck*> CBreakPoints::cleanupMemChecks_;
 bool CBreakPoints::breakpointTriggered_ = false;
 BreakPointCpu CBreakPoints::breakpointTriggeredCpu_;
 bool CBreakPoints::corePaused = false;
+
+namespace
+{
+	InstructionTracer::TraceEvent BuildTraceEvent(BreakPointCpu cpu)
+	{
+		DebugInterface& iface = DebugInterface::get(cpu);
+
+		InstructionTracer::TraceEvent event;
+		event.cpu = cpu;
+		event.pc = iface.getPC();
+		event.opcode = iface.read32(event.pc);
+		event.disasm = iface.disasm(event.pc, true);
+		event.cycles = iface.getCycles();
+		event.timestamp_ns = InstructionTracer::MonotonicTimestamp();
+		return event;
+	}
+
+	void RecordTraceEvent(BreakPointCpu cpu)
+	{
+		if (!InstructionTracer::IsEnabled(cpu))
+			return;
+
+		InstructionTracer::Record(cpu, BuildTraceEvent(cpu));
+	}
+}
 
 // called from the dynarec
 u32 standardizeBreakpointAddress(u32 addr)
@@ -51,6 +78,7 @@ MemCheck::MemCheck()
 
 void MemCheck::Log(u32 addr, bool write, int size, u32 pc)
 {
+        MemoryScannerHooks::OnMemCheckHit(*this, addr, write, size, pc);
 }
 
 void MemCheck::Action(u32 addr, bool write, int size, u32 pc)
@@ -417,6 +445,15 @@ void CBreakPoints::ClearSkipFirst()
 	breakSkipFirstTicksEE_ = 0;
 	breakSkipFirstAtIop_ = 0;
 	breakSkipFirstTicksIop_ = 0;
+}
+
+void CBreakPoints::SetBreakpointTriggered(bool triggered, BreakPointCpu cpu)
+{
+	breakpointTriggered_ = triggered;
+	breakpointTriggeredCpu_ = cpu;
+
+	if (triggered)
+		RecordTraceEvent(cpu);
 }
 
 const std::vector<MemCheck> CBreakPoints::GetMemCheckRanges()

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -151,11 +151,7 @@ public:
 
 	static void Update(BreakPointCpu cpu = BREAKPOINT_IOP_AND_EE, u32 addr = 0);
 
-	static void SetBreakpointTriggered(bool triggered, BreakPointCpu cpu = BreakPointCpu::BREAKPOINT_IOP_AND_EE)
-	{
-		breakpointTriggered_ = triggered;
-		breakpointTriggeredCpu_ = cpu;
-	};
+        static void SetBreakpointTriggered(bool triggered, BreakPointCpu cpu = BreakPointCpu::BREAKPOINT_IOP_AND_EE);
 	static bool GetBreakpointTriggered() { return breakpointTriggered_; };
 	static BreakPointCpu GetBreakpointTriggeredCpu() { return breakpointTriggeredCpu_; };
 

--- a/pcsx2/DebugTools/InstructionTracer.cpp
+++ b/pcsx2/DebugTools/InstructionTracer.cpp
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "InstructionTracer.h"
+
+#include "common/Assertions.h"
+#include "common/FileSystem.h"
+#include "common/Path.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <charconv>
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <limits>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace InstructionTracer
+{
+        namespace
+        {
+                using Clock = std::chrono::steady_clock;
+
+                constexpr size_t kDefaultCapacity = 8192;
+
+                constexpr size_t cpuIndex(BreakPointCpu cpu)
+                {
+                        switch (cpu)
+                        {
+                                case BREAKPOINT_EE:
+                                        return 0;
+                                case BREAKPOINT_IOP:
+                                        return 1;
+                                case BREAKPOINT_IOP_AND_EE:
+                                        return 0;
+                                default:
+                                        return 0;
+                        }
+                }
+
+                class RingBuffer
+                {
+                public:
+                        explicit RingBuffer(size_t capacity)
+                                : m_capacity(capacity)
+                                , m_mask(capacity - 1)
+                                , m_buffer(capacity)
+                        {
+                                pxAssertRel((capacity != 0) && ((capacity & (capacity - 1)) == 0), "capacity must be power of two");
+                        }
+
+                        void push(const TraceEvent& ev)
+                        {
+                                const size_t head = m_head.load(std::memory_order_relaxed);
+                                size_t tail = m_tail.load(std::memory_order_acquire);
+                                const size_t next = head + 1;
+
+                                if ((next - tail) > m_capacity)
+                                {
+                                        tail = tail + 1;
+                                        m_tail.store(tail, std::memory_order_release);
+                                        ++m_dropped;
+                                }
+
+                                m_buffer[head & m_mask] = ev;
+                                m_head.store(next, std::memory_order_release);
+                        }
+
+                        template <typename OutputIt>
+                        size_t drain(size_t n, OutputIt it)
+                        {
+                                size_t drained = 0;
+                                size_t tail = m_tail.load(std::memory_order_relaxed);
+                                const size_t head = m_head.load(std::memory_order_acquire);
+
+                                while ((tail != head) && (drained < n))
+                                {
+                                        *it++ = m_buffer[tail & m_mask];
+                                        ++tail;
+                                        ++drained;
+                                }
+
+                                m_tail.store(tail, std::memory_order_release);
+                                return drained;
+                        }
+
+                        size_t size() const
+                        {
+                                const size_t head = m_head.load(std::memory_order_acquire);
+                                const size_t tail = m_tail.load(std::memory_order_acquire);
+                                return head - tail;
+                        }
+
+                        void clear()
+                        {
+                                m_tail.store(m_head.load(std::memory_order_acquire), std::memory_order_release);
+                        }
+
+                        size_t dropped() const
+                        {
+                                return m_dropped.load(std::memory_order_relaxed);
+                        }
+
+                private:
+                        const size_t m_capacity;
+                        const size_t m_mask;
+                        std::vector<TraceEvent> m_buffer;
+                        std::atomic<size_t> m_head{0};
+                        std::atomic<size_t> m_tail{0};
+                        std::atomic<size_t> m_dropped{0};
+                };
+
+                struct CpuState
+                {
+                        std::atomic<bool> enabled{false};
+                        RingBuffer ring{kDefaultCapacity};
+                        std::mutex io_mutex;
+
+                        CpuState() = default;
+                        CpuState(const CpuState&) = delete;
+                        CpuState& operator=(const CpuState&) = delete;
+                };
+
+                std::array<CpuState, 2> g_cpu_state = {CpuState{}, CpuState{}};
+
+                std::string ToNativePath(const std::filesystem::path& path)
+                {
+                        return Path::ToNativePath(path.string());
+                }
+
+                std::string TempPathFor(const std::filesystem::path& path)
+                {
+                        std::filesystem::path temp = path;
+                        temp += ".tmp";
+                        return Path::ToNativePath(temp.string());
+                }
+
+                std::string Escape(std::string_view input)
+                {
+                        std::string out;
+                        out.reserve(input.size() + 8);
+                        for (char ch : input)
+                        {
+                                switch (ch)
+                                {
+                                        case '\\':
+                                                out += "\\\\";
+                                                break;
+                                        case '"':
+                                                out += "\\\"";
+                                                break;
+                                        case '\n':
+                                                out += "\\n";
+                                                break;
+                                        case '\r':
+                                                out += "\\r";
+                                                break;
+                                        case '\t':
+                                                out += "\\t";
+                                                break;
+                                        default:
+                                                out.push_back(ch);
+                                                break;
+                                }
+                        }
+                        return out;
+                }
+
+                std::string CpuName(BreakPointCpu cpu)
+                {
+                        return DebugInterface::cpuName(cpu);
+                }
+
+                std::string FormatAddress(u64 value)
+                {
+                        char buffer[32];
+                        const auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), value, 16);
+                        if (ec != std::errc())
+                                return "0x0";
+                        std::string out = "0x";
+                        out.append(buffer, ptr);
+                        return out;
+                }
+
+                void WriteEventLine(std::FILE* fp, const TraceEvent& ev)
+                {
+                        const double timestamp = static_cast<double>(ev.timestamp_ns) / 1'000'000'000.0;
+                        std::string disasm = Escape(ev.disasm);
+
+                        std::fputs("{", fp);
+                        std::fprintf(fp, "\"ts\":%.9f,", timestamp);
+                        std::fprintf(fp, "\"cpu\":\"%s\",", CpuName(ev.cpu).c_str());
+                        std::fprintf(fp, "\"pc\":\"%s\",", FormatAddress(ev.pc).c_str());
+                        std::fprintf(fp, "\"opcode\":%u,", ev.opcode);
+                        std::fprintf(fp, "\"cycles\":%llu,", static_cast<unsigned long long>(ev.cycles));
+                        std::fprintf(fp, "\"op\":\"%s\"", disasm.c_str());
+
+                        if (!ev.mem_reads.empty() || !ev.mem_writes.empty())
+                        {
+                                std::fputs(",\"mem\":{", fp);
+                                if (!ev.mem_reads.empty())
+                                {
+                                        std::fputs("\"r\":[", fp);
+                                        bool first = true;
+                                        for (const auto& [addr, size] : ev.mem_reads)
+                                        {
+                                                if (!first)
+                                                        std::fputc(',', fp);
+                                                std::fprintf(fp, "[\"%s\",%u]", FormatAddress(addr).c_str(), size);
+                                                first = false;
+                                        }
+                                        std::fputc(']', fp);
+                                        if (!ev.mem_writes.empty())
+                                                std::fputc(',', fp);
+                                }
+                                if (!ev.mem_writes.empty())
+                                {
+                                        std::fputs("\"w\":[", fp);
+                                        bool first = true;
+                                        for (const auto& [addr, size] : ev.mem_writes)
+                                        {
+                                                if (!first)
+                                                        std::fputc(',', fp);
+                                                std::fprintf(fp, "[\"%s\",%u]", FormatAddress(addr).c_str(), size);
+                                                first = false;
+                                        }
+                                        std::fputc(']', fp);
+                                }
+                                std::fputc('}', fp);
+                        }
+
+                        std::fputs("}\n", fp);
+                }
+        }
+
+        void Enable(BreakPointCpu cpu, bool on)
+        {
+                g_cpu_state[cpuIndex(cpu)].enabled.store(on, std::memory_order_release);
+                if (!on)
+                        Clear(cpu);
+        }
+
+        bool IsEnabled(BreakPointCpu cpu)
+        {
+                return g_cpu_state[cpuIndex(cpu)].enabled.load(std::memory_order_acquire);
+        }
+
+        void Record(BreakPointCpu cpu, const TraceEvent& ev)
+        {
+                const size_t index = cpuIndex(cpu);
+                if (!g_cpu_state[index].enabled.load(std::memory_order_acquire))
+                        return;
+
+                g_cpu_state[index].ring.push(ev);
+        }
+
+        std::vector<TraceEvent> Drain(BreakPointCpu cpu, size_t n)
+        {
+                const size_t index = cpuIndex(cpu);
+                size_t limit = n == 0 ? std::numeric_limits<size_t>::max() : n;
+                std::vector<TraceEvent> buffer;
+                buffer.reserve(std::min(limit, g_cpu_state[index].ring.size()));
+                g_cpu_state[index].ring.drain(limit, std::back_inserter(buffer));
+                return buffer;
+        }
+
+        bool DumpToFile(BreakPointCpu cpu, const std::filesystem::path& path, const DumpBounds& bounds)
+        {
+                const size_t index = cpuIndex(cpu);
+                std::lock_guard<std::mutex> guard(g_cpu_state[index].io_mutex);
+
+                const std::string temp_path = TempPathFor(path);
+                auto file = FileSystem::OpenManagedCFile(temp_path.c_str(), "wb");
+                if (!file)
+                        return false;
+
+                size_t limit = bounds.limit.value_or(std::numeric_limits<size_t>::max());
+                std::vector<TraceEvent> buffer = Drain(cpu, limit);
+                for (const TraceEvent& ev : buffer)
+                        WriteEventLine(file.get(), ev);
+
+                file.reset();
+                return FileSystem::RenamePath(temp_path.c_str(), ToNativePath(path).c_str());
+        }
+
+        size_t PendingCount(BreakPointCpu cpu)
+        {
+                return g_cpu_state[cpuIndex(cpu)].ring.size();
+        }
+
+        void Clear(BreakPointCpu cpu)
+        {
+                g_cpu_state[cpuIndex(cpu)].ring.clear();
+        }
+
+        u64 MonotonicTimestamp()
+        {
+                return std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now().time_since_epoch()).count();
+        }
+}

--- a/pcsx2/DebugTools/InstructionTracer.h
+++ b/pcsx2/DebugTools/InstructionTracer.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "DebugInterface.h"
+
+#include "common/Pcsx2Types.h"
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace InstructionTracer
+{
+        struct TraceEvent
+        {
+                BreakPointCpu cpu = BREAKPOINT_EE;
+                u64 pc = 0;
+                u32 opcode = 0;
+                std::string disasm;
+                u64 cycles = 0;
+                u64 timestamp_ns = 0;
+
+                using MemorySummary = std::vector<std::pair<u64, u8>>;
+
+                MemorySummary mem_reads;
+                MemorySummary mem_writes;
+        };
+
+        struct DumpBounds
+        {
+                std::optional<u64> limit;
+        };
+
+        void Enable(BreakPointCpu cpu, bool on);
+        bool IsEnabled(BreakPointCpu cpu);
+        void Record(BreakPointCpu cpu, const TraceEvent& ev);
+
+        std::vector<TraceEvent> Drain(BreakPointCpu cpu, size_t n = 0);
+
+        bool DumpToFile(BreakPointCpu cpu, const std::filesystem::path& path, const DumpBounds& bounds = {});
+        size_t PendingCount(BreakPointCpu cpu);
+        void Clear(BreakPointCpu cpu);
+
+        u64 MonotonicTimestamp();
+
+}

--- a/pcsx2/DebugTools/MemoryScanner.cpp
+++ b/pcsx2/DebugTools/MemoryScanner.cpp
@@ -1,0 +1,433 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "MemoryScanner.h"
+
+#include "Breakpoints.h"
+#include "DebugInterface.h"
+#include "InstructionTracer.h"
+
+#include "common/FileSystem.h"
+#include "common/Path.h"
+
+#include "pcsx2/Host.h"
+#include "pcsx2/VMManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+
+namespace
+{
+        template <typename T>
+        T LoadValue(const u8* base)
+        {
+                T value;
+                std::memcpy(&value, base, sizeof(T));
+                return value;
+        }
+
+        bool ReadRange(DebugInterface& cpu, u64 begin, u64 end, std::vector<u8>& out)
+        {
+                if (end <= begin)
+                        return false;
+
+                const u64 size = end - begin;
+                out.resize(size);
+
+                for (u64 offset = 0; offset < size; ++offset)
+                {
+                        out[offset] = static_cast<u8>(cpu.read8(static_cast<u32>(begin + offset)));
+                }
+
+                return true;
+        }
+
+        std::string ToNativePath(const std::filesystem::path& path)
+        {
+                return Path::ToNativePath(path.string());
+        }
+
+        std::string TempPathFor(const std::filesystem::path& path)
+        {
+                std::filesystem::path temp = path;
+                temp += ".tmp";
+                return Path::ToNativePath(temp.string());
+        }
+}
+
+MemoryScanner& MemoryScanner::Get()
+{
+        static MemoryScanner instance;
+        return instance;
+}
+
+MemoryScanner::ScanId MemoryScanner::AllocateId()
+{
+        return m_next_id.fetch_add(1, std::memory_order_relaxed);
+}
+
+bool MemoryScanner::SnapshotRange(const Query& query, std::vector<u8>& out_snapshot, bool run_on_cpu_thread) const
+{
+        if (run_on_cpu_thread)
+        {
+                bool ok = false;
+                Host::RunOnCPUThread(
+                        [&]() {
+                                DebugInterface& cpu = DebugInterface::get(query.cpu);
+                                ok = ReadRange(cpu, query.begin, query.end, out_snapshot);
+                        },
+                        true);
+                return ok;
+        }
+
+        DebugInterface& cpu = DebugInterface::get(query.cpu);
+        return ReadRange(cpu, query.begin, query.end, out_snapshot);
+}
+
+size_t MemoryScanner::ValueSize(ValueType type)
+{
+        switch (type)
+        {
+                case ValueType::U8:
+                        return sizeof(u8);
+                case ValueType::U16:
+                        return sizeof(u16);
+                case ValueType::U32:
+                        return sizeof(u32);
+                case ValueType::U64:
+                        return sizeof(u64);
+                case ValueType::F32:
+                        return sizeof(float);
+                case ValueType::F64:
+                        return sizeof(double);
+                default:
+                        return sizeof(u8);
+        }
+}
+
+bool MemoryScanner::Evaluate(const Query& query, const u8* base) const
+{
+        switch (query.type)
+        {
+                case ValueType::U8:
+                {
+                        const u64 actual = LoadValue<u8>(base);
+                        const u64 expected = query.value.integer & 0xFFu;
+                        switch (query.comparison)
+                        {
+                                case Comparison::Equal:
+                                        return actual == expected;
+                                case Comparison::NotEqual:
+                                        return actual != expected;
+                                case Comparison::Greater:
+                                        return actual > expected;
+                                case Comparison::Less:
+                                        return actual < expected;
+                                case Comparison::Approximate:
+                                        return std::abs(static_cast<double>(actual) - static_cast<double>(expected)) <= query.epsilon;
+                        }
+                        break;
+                }
+                case ValueType::U16:
+                {
+                        const u64 actual = LoadValue<u16>(base);
+                        const u64 expected = query.value.integer & 0xFFFFu;
+                        switch (query.comparison)
+                        {
+                                case Comparison::Equal:
+                                        return actual == expected;
+                                case Comparison::NotEqual:
+                                        return actual != expected;
+                                case Comparison::Greater:
+                                        return actual > expected;
+                                case Comparison::Less:
+                                        return actual < expected;
+                                case Comparison::Approximate:
+                                        return std::abs(static_cast<double>(actual) - static_cast<double>(expected)) <= query.epsilon;
+                        }
+                        break;
+                }
+                case ValueType::U32:
+                {
+                        const u64 actual = LoadValue<u32>(base);
+                        const u64 expected = static_cast<u32>(query.value.integer);
+                        switch (query.comparison)
+                        {
+                                case Comparison::Equal:
+                                        return actual == expected;
+                                case Comparison::NotEqual:
+                                        return actual != expected;
+                                case Comparison::Greater:
+                                        return actual > expected;
+                                case Comparison::Less:
+                                        return actual < expected;
+                                case Comparison::Approximate:
+                                        return std::abs(static_cast<double>(actual) - static_cast<double>(expected)) <= query.epsilon;
+                        }
+                        break;
+                }
+                case ValueType::U64:
+                {
+                        const u64 actual = LoadValue<u64>(base);
+                        const u64 expected = query.value.integer;
+                        switch (query.comparison)
+                        {
+                                case Comparison::Equal:
+                                        return actual == expected;
+                                case Comparison::NotEqual:
+                                        return actual != expected;
+                                case Comparison::Greater:
+                                        return actual > expected;
+                                case Comparison::Less:
+                                        return actual < expected;
+                                case Comparison::Approximate:
+                                        return std::abs(static_cast<double>(actual) - static_cast<double>(expected)) <= query.epsilon;
+                        }
+                        break;
+                }
+                case ValueType::F32:
+                {
+                        const double actual = static_cast<double>(LoadValue<float>(base));
+                        const double expected = static_cast<double>(query.value.floating);
+                        switch (query.comparison)
+                        {
+                                case Comparison::Equal:
+                                        return actual == expected;
+                                case Comparison::NotEqual:
+                                        return actual != expected;
+                                case Comparison::Greater:
+                                        return actual > expected;
+                                case Comparison::Less:
+                                        return actual < expected;
+                                case Comparison::Approximate:
+                                        return std::fabs(actual - expected) <= query.epsilon;
+                        }
+                        break;
+                }
+                case ValueType::F64:
+                {
+                        const double actual = LoadValue<double>(base);
+                        const double expected = query.value.floating;
+                        switch (query.comparison)
+                        {
+                                case Comparison::Equal:
+                                        return actual == expected;
+                                case Comparison::NotEqual:
+                                        return actual != expected;
+                                case Comparison::Greater:
+                                        return actual > expected;
+                                case Comparison::Less:
+                                        return actual < expected;
+                                case Comparison::Approximate:
+                                        return std::fabs(actual - expected) <= query.epsilon;
+                        }
+                        break;
+                }
+        }
+
+        return false;
+}
+
+void MemoryScanner::PerformScan(ScanJob& job, const Query& query)
+{
+        job.query = query;
+        job.results.clear();
+        if (query.end <= query.begin)
+                return;
+
+        if (!SnapshotRange(query, job.snapshot, true))
+                return;
+
+        const size_t element_size = ValueSize(query.type);
+        if (element_size == 0)
+                return;
+
+        const u64 range_size = query.end - query.begin;
+        for (u64 offset = 0; offset + element_size <= range_size; offset += element_size)
+        {
+                if (Evaluate(query, job.snapshot.data() + offset))
+                {
+                        Result result;
+                        result.address = query.begin + offset;
+                        result.bytes.assign(job.snapshot.data() + offset, job.snapshot.data() + offset + element_size);
+                        job.results.push_back(std::move(result));
+                }
+        }
+}
+
+MemoryScanner::ScanId MemoryScanner::SubmitInitial(const Query& query)
+{
+        if (query.end <= query.begin)
+                return kInvalidScanId;
+
+        if (VMManager::GetState() != VMState::Paused)
+                return kInvalidScanId;
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        ScanJob job;
+        PerformScan(job, query);
+
+        if (job.results.empty() && job.snapshot.empty())
+                return kInvalidScanId;
+
+        const ScanId id = AllocateId();
+        m_jobs.emplace(id, std::move(job));
+        return id;
+}
+
+MemoryScanner::ScanId MemoryScanner::SubmitRescan(ScanId id, const Query& query)
+{
+        if (id == kInvalidScanId)
+                return kInvalidScanId;
+
+        if (VMManager::GetState() != VMState::Paused)
+                return kInvalidScanId;
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto it = m_jobs.find(id);
+        if (it == m_jobs.end())
+                return kInvalidScanId;
+
+        PerformScan(it->second, query);
+        return id;
+}
+
+void MemoryScanner::Cancel(ScanId id)
+{
+        if (id == kInvalidScanId)
+                return;
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_jobs.erase(id);
+}
+
+std::vector<MemoryScanner::Result> MemoryScanner::Results(ScanId id) const
+{
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto it = m_jobs.find(id);
+        if (it == m_jobs.end())
+                return {};
+        return it->second.results;
+}
+
+bool MemoryScanner::DumpOnChange(BreakPointCpu cpu, u64 addr, const std::filesystem::path& out_path, const DumpSpec& spec)
+{
+        if (spec.size == 0)
+                return false;
+
+        Watch watch;
+        watch.cpu = cpu;
+        watch.spec = spec;
+        watch.spec.start = spec.start != 0 ? spec.start : addr;
+        watch.out_path = out_path;
+
+        bool inserted = false;
+        {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                auto existing = std::find_if(m_watches.begin(), m_watches.end(), [&](const Watch& other) {
+                        return other.cpu == watch.cpu && other.spec.start == watch.spec.start &&
+                               other.spec.size == watch.spec.size && other.out_path == watch.out_path;
+                });
+
+                if (existing != m_watches.end())
+                        *existing = watch;
+                else
+                {
+                        m_watches.push_back(watch);
+                        inserted = true;
+                }
+        }
+
+        if (inserted)
+        {
+                const u32 start = static_cast<u32>(watch.spec.start);
+                const u32 end = static_cast<u32>(watch.spec.start + spec.size);
+                CBreakPoints::AddMemCheck(cpu, start, end, static_cast<MemCheckCondition>(MEMCHECK_WRITE | MEMCHECK_WRITE_ONCHANGE),
+                        MEMCHECK_LOG);
+        }
+        return true;
+}
+
+bool MemoryScanner::WriteDump(const Watch& watch) const
+{
+        std::vector<u8> buffer;
+        Query query;
+        query.cpu = watch.cpu;
+        query.begin = watch.spec.start;
+        query.end = watch.spec.start + watch.spec.size;
+        query.type = ValueType::U8;
+
+        if (!SnapshotRange(query, buffer, false))
+                return false;
+
+        const std::string temp_path = TempPathFor(watch.out_path);
+        auto file = FileSystem::OpenManagedCFile(temp_path.c_str(), "wb");
+        if (!file)
+                return false;
+
+        if (watch.spec.include_metadata)
+        {
+                std::fprintf(
+                        file.get(),
+                        "{ \"version\":1, \"space\":\"%s\", \"start\":%u, \"size\":%u }\n--\n",
+                        DebugInterface::cpuName(watch.cpu),
+                        static_cast<u32>(watch.spec.start),
+                        watch.spec.size);
+        }
+
+        if (!buffer.empty())
+                std::fwrite(buffer.data(), 1, buffer.size(), file.get());
+
+        file.reset();
+        return FileSystem::RenamePath(temp_path.c_str(), ToNativePath(watch.out_path).c_str());
+}
+
+void MemoryScanner::HandleMemCheckHit(const MemCheck& memcheck, u32 addr, bool write, int size, u32 pc)
+{
+        if (InstructionTracer::IsEnabled(memcheck.cpu))
+        {
+                DebugInterface& iface = DebugInterface::get(memcheck.cpu);
+                InstructionTracer::TraceEvent event;
+                event.cpu = memcheck.cpu;
+                event.pc = pc ? pc : iface.getPC();
+                event.opcode = iface.read32(event.pc);
+                event.disasm = iface.disasm(event.pc, true);
+                event.cycles = iface.getCycles();
+                event.timestamp_ns = InstructionTracer::MonotonicTimestamp();
+
+                const u8 clamped_size = size > 0 ? static_cast<u8>(std::min(size, 255)) : 0;
+                auto& summary = write ? event.mem_writes : event.mem_reads;
+                summary.emplace_back(static_cast<u64>(addr), clamped_size);
+
+                InstructionTracer::Record(memcheck.cpu, event);
+        }
+
+        std::vector<Watch> to_process;
+        {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                for (const Watch& watch : m_watches)
+                {
+                        if (watch.cpu != memcheck.cpu)
+                                continue;
+                        if (addr < watch.spec.start)
+                                continue;
+                        if (addr >= (watch.spec.start + watch.spec.size))
+                                continue;
+                        to_process.push_back(watch);
+                }
+        }
+
+        for (const Watch& watch : to_process)
+                WriteDump(watch);
+}
+
+namespace MemoryScannerHooks
+{
+        void OnMemCheckHit(const MemCheck& memcheck, u32 addr, bool write, int size, u32 pc)
+        {
+                MemoryScanner::Get().HandleMemCheckHit(memcheck, addr, write, size, pc);
+        }
+}

--- a/pcsx2/DebugTools/MemoryScanner.h
+++ b/pcsx2/DebugTools/MemoryScanner.h
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "DebugInterface.h"
+
+#include <atomic>
+#include <filesystem>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+struct MemCheck;
+
+class MemoryScanner
+{
+public:
+        enum class ValueType
+        {
+                U8,
+                U16,
+                U32,
+                U64,
+                F32,
+                F64
+        };
+
+        enum class Comparison
+        {
+                Equal,
+                NotEqual,
+                Greater,
+                Less,
+                Approximate
+        };
+
+        struct Value
+        {
+                u64 integer = 0;
+                double floating = 0.0;
+        };
+
+        struct Query
+        {
+                BreakPointCpu cpu = BREAKPOINT_EE;
+                u64 begin = 0;
+                u64 end = 0;
+                ValueType type = ValueType::U8;
+                Comparison comparison = Comparison::Equal;
+                Value value;
+                double epsilon = 0.0;
+        };
+
+        struct Result
+        {
+                u64 address = 0;
+                std::vector<u8> bytes;
+        };
+
+        struct DumpSpec
+        {
+                u64 start = 0;
+                u32 size = 0;
+                bool include_metadata = true;
+        };
+
+        using ScanId = u64;
+
+        static constexpr ScanId kInvalidScanId = 0;
+
+        static MemoryScanner& Get();
+
+        ScanId SubmitInitial(const Query& query);
+        ScanId SubmitRescan(ScanId id, const Query& query);
+        void Cancel(ScanId id);
+        std::vector<Result> Results(ScanId id) const;
+
+        bool DumpOnChange(BreakPointCpu cpu, u64 addr, const std::filesystem::path& out_path, const DumpSpec& spec);
+        void HandleMemCheckHit(const MemCheck& memcheck, u32 addr, bool write, int size, u32 pc);
+
+private:
+        struct ScanJob
+        {
+                Query query;
+                std::vector<u8> snapshot;
+                std::vector<Result> results;
+        };
+
+        struct Watch
+        {
+                BreakPointCpu cpu = BREAKPOINT_EE;
+                DumpSpec spec;
+                std::filesystem::path out_path;
+        };
+
+        MemoryScanner() = default;
+
+        bool SnapshotRange(const Query& query, std::vector<u8>& out_snapshot, bool run_on_cpu_thread) const;
+        void PerformScan(ScanJob& job, const Query& query);
+        bool Evaluate(const Query& query, const u8* base) const;
+        static size_t ValueSize(ValueType type);
+        bool WriteDump(const Watch& watch) const;
+
+        ScanId AllocateId();
+
+        mutable std::mutex m_mutex;
+        std::unordered_map<ScanId, ScanJob> m_jobs;
+        std::vector<Watch> m_watches;
+        std::atomic<ScanId> m_next_id{1};
+};
+
+namespace MemoryScannerHooks
+{
+        void OnMemCheckHit(const MemCheck& memcheck, u32 addr, bool write, int size, u32 pc);
+}


### PR DESCRIPTION
## Summary
- emit InstructionTracer events when CPU breakpoints trip to capture PC/opcode/disassembly
- log memcheck activity through InstructionTracer with memory summaries and enforce paused scans
- require paused VM before running MemoryScanner jobs and ensure dump-on-change installs write-on-change memchecks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7b4b7461c8328ac3901e7943802af