### PR TITLE
Handle MCPServer parse errors and add tests

### DIFF
--- a/pcsx2/DebugTools/MCPServer.cpp
+++ b/pcsx2/DebugTools/MCPServer.cpp
@@ -8,14 +8,29 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <functional>
 #include <iostream>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <utility>
 
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
 namespace DebugTools::MCPServer
 {
+namespace detail
+{
+using ResponseSink = std::function<void(std::string_view)>;
+
+void SetResponseSinkForTesting(ResponseSink sink);
+void ResetResponseSinkForTesting();
+void ProcessCommandLine(std::string&& line);
+} // namespace detail
+
 namespace
 {
 std::atomic_bool g_running{false};
@@ -24,10 +39,62 @@ std::condition_variable s_state_cv;
 std::thread s_stdio_thread;
 bool s_worker_active = false;
 
-[[maybe_unused]] void ProcessCommandLine(std::string&& line)
+std::mutex s_response_sink_mutex;
+detail::ResponseSink s_response_sink;
+
+void DispatchResponse(std::string&& response)
 {
-    // Placeholder for command handling integration.
-    (void)line;
+    detail::ResponseSink sink;
+    {
+        std::lock_guard<std::mutex> lock(s_response_sink_mutex);
+        sink = s_response_sink;
+    }
+
+    if (sink)
+    {
+        sink(response);
+        return;
+    }
+
+    std::cout << response;
+    std::cout.flush();
+}
+
+void WriteResponseDocument(rapidjson::Document& document)
+{
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    document.Accept(writer);
+
+    std::string serialized(buffer.GetString(), buffer.GetSize());
+    serialized.push_back('\n');
+
+    DispatchResponse(std::move(serialized));
+}
+
+void WriteErrorResponse(const rapidjson::Value* id, const char* code, const char* message)
+{
+    rapidjson::Document response(rapidjson::kObjectType);
+    rapidjson::Document::AllocatorType& allocator = response.GetAllocator();
+
+    if (id)
+    {
+        rapidjson::Value id_copy(*id, allocator);
+        response.AddMember("id", std::move(id_copy), allocator);
+    }
+    else
+    {
+        response.AddMember("id", rapidjson::Value().SetNull(), allocator);
+    }
+
+    response.AddMember("ok", false, allocator);
+
+    rapidjson::Value error(rapidjson::kObjectType);
+    error.AddMember("code", rapidjson::Value().SetString(code, allocator), allocator);
+    error.AddMember("message", rapidjson::Value().SetString(message, allocator), allocator);
+    response.AddMember("error", std::move(error), allocator);
+
+    WriteResponseDocument(response);
 }
 
 void StdioWorker()
@@ -79,7 +146,7 @@ void StdioWorker()
                 line.pop_back();
 
             if (!line.empty())
-                ProcessCommandLine(std::move(line));
+                detail::ProcessCommandLine(std::move(line));
         }
     }
 
@@ -93,6 +160,70 @@ void StdioWorker()
     s_state_cv.notify_all();
 }
 } // namespace
+
+namespace detail
+{
+namespace
+{
+constexpr const char* ERROR_CODE_PARSE = "parse_error";
+constexpr const char* ERROR_CODE_INVALID_REQUEST = "invalid_request";
+constexpr const char* ERROR_CODE_UNSUPPORTED = "not_implemented";
+
+constexpr const char* ERROR_MESSAGE_PARSE = "Failed to parse request";
+constexpr const char* ERROR_MESSAGE_INVALID_ID = "Missing id";
+constexpr const char* ERROR_MESSAGE_INVALID_OBJECT = "Request must be an object";
+constexpr const char* ERROR_MESSAGE_INVALID_CMD = "Missing or invalid cmd";
+constexpr const char* ERROR_MESSAGE_UNSUPPORTED = "Command handling is not implemented";
+} // namespace
+
+void SetResponseSinkForTesting(ResponseSink sink)
+{
+    std::lock_guard<std::mutex> lock(s_response_sink_mutex);
+    s_response_sink = std::move(sink);
+}
+
+void ResetResponseSinkForTesting()
+{
+    std::lock_guard<std::mutex> lock(s_response_sink_mutex);
+    s_response_sink = ResponseSink{};
+}
+
+void ProcessCommandLine(std::string&& line)
+{
+    rapidjson::Document request;
+    request.Parse(line.c_str(), line.size());
+
+    if (request.HasParseError())
+    {
+        WriteErrorResponse(nullptr, ERROR_CODE_PARSE, ERROR_MESSAGE_PARSE);
+        return;
+    }
+
+    if (!request.IsObject())
+    {
+        WriteErrorResponse(nullptr, ERROR_CODE_INVALID_REQUEST, ERROR_MESSAGE_INVALID_OBJECT);
+        return;
+    }
+
+    auto id_member = request.FindMember("id");
+    if (id_member == request.MemberEnd())
+    {
+        WriteErrorResponse(nullptr, ERROR_CODE_INVALID_REQUEST, ERROR_MESSAGE_INVALID_ID);
+        return;
+    }
+
+    const rapidjson::Value* id_value = &id_member->value;
+
+    auto cmd_member = request.FindMember("cmd");
+    if (cmd_member == request.MemberEnd() || !cmd_member->value.IsString())
+    {
+        WriteErrorResponse(id_value, ERROR_CODE_INVALID_REQUEST, ERROR_MESSAGE_INVALID_CMD);
+        return;
+    }
+
+    WriteErrorResponse(id_value, ERROR_CODE_UNSUPPORTED, ERROR_MESSAGE_UNSUPPORTED);
+}
+} // namespace detail
 
 bool Initialize()
 {

--- a/tests/ctest/CMakeLists.txt
+++ b/tests/ctest/CMakeLists.txt
@@ -25,3 +25,4 @@ endmacro()
 
 add_subdirectory(common)
 add_subdirectory(core)
+add_subdirectory(debugtools)

--- a/tests/ctest/debugtools/CMakeLists.txt
+++ b/tests/ctest/debugtools/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_pcsx2_test(debugtools_mcp_server_tests
+        mcp_server_tests.cpp
+        ../../../pcsx2/DebugTools/MCPServer.cpp
+)
+
+target_include_directories(debugtools_mcp_server_tests PRIVATE
+        ${CMAKE_SOURCE_DIR}/pcsx2
+        ${CMAKE_SOURCE_DIR}/3rdparty/rapidjson/include
+)

--- a/tests/ctest/debugtools/mcp_server_tests.cpp
+++ b/tests/ctest/debugtools/mcp_server_tests.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "gtest/gtest.h"
+
+#include "rapidjson/document.h"
+
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace DebugTools::MCPServer::detail
+{
+using ResponseSink = std::function<void(std::string_view)>;
+
+void SetResponseSinkForTesting(ResponseSink sink);
+void ResetResponseSinkForTesting();
+void ProcessCommandLine(std::string&& line);
+} // namespace DebugTools::MCPServer::detail
+
+namespace
+{
+class ResponseCaptureTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        responses.clear();
+        DebugTools::MCPServer::detail::SetResponseSinkForTesting(
+                [this](std::string_view payload) { responses.emplace_back(payload); });
+    }
+
+    void TearDown() override
+    {
+        DebugTools::MCPServer::detail::ResetResponseSinkForTesting();
+    }
+
+    std::vector<std::string> responses;
+};
+} // namespace
+
+TEST_F(ResponseCaptureTest, EmitsErrorForMalformedJson)
+{
+    DebugTools::MCPServer::detail::ProcessCommandLine(std::string("{oops"));
+
+    ASSERT_EQ(responses.size(), 1u);
+
+    rapidjson::Document parsed;
+    parsed.Parse(responses.front().c_str(), responses.front().size());
+
+    ASSERT_FALSE(parsed.HasParseError());
+    ASSERT_TRUE(parsed.IsObject());
+    ASSERT_TRUE(parsed.HasMember("id"));
+    EXPECT_TRUE(parsed["id"].IsNull());
+    ASSERT_TRUE(parsed.HasMember("ok"));
+    EXPECT_FALSE(parsed["ok"].GetBool());
+    ASSERT_TRUE(parsed.HasMember("error"));
+    const rapidjson::Value& error = parsed["error"];
+    ASSERT_TRUE(error.IsObject());
+    ASSERT_TRUE(error.HasMember("code"));
+    EXPECT_STREQ("parse_error", error["code"].GetString());
+    ASSERT_TRUE(error.HasMember("message"));
+    EXPECT_STREQ("Failed to parse request", error["message"].GetString());
+}
+
+TEST_F(ResponseCaptureTest, EmitsErrorWhenIdMissing)
+{
+    DebugTools::MCPServer::detail::ProcessCommandLine(std::string(R"({"cmd":"noop"})"));
+
+    ASSERT_EQ(responses.size(), 1u);
+
+    rapidjson::Document parsed;
+    parsed.Parse(responses.front().c_str(), responses.front().size());
+
+    ASSERT_FALSE(parsed.HasParseError());
+    ASSERT_TRUE(parsed.IsObject());
+    ASSERT_TRUE(parsed.HasMember("id"));
+    EXPECT_TRUE(parsed["id"].IsNull());
+    ASSERT_TRUE(parsed.HasMember("ok"));
+    EXPECT_FALSE(parsed["ok"].GetBool());
+    ASSERT_TRUE(parsed.HasMember("error"));
+    const rapidjson::Value& error = parsed["error"];
+    ASSERT_TRUE(error.IsObject());
+    ASSERT_TRUE(error.HasMember("code"));
+    EXPECT_STREQ("invalid_request", error["code"].GetString());
+    ASSERT_TRUE(error.HasMember("message"));
+    EXPECT_STREQ("Missing id", error["message"].GetString());
+}
+


### PR DESCRIPTION
## Summary
- ensure the MCP server now emits deterministic error responses for malformed JSON and missing identifiers
- expose a configurable response sink to make the command processor testable and cover the new error paths
- register a debug tools unit-test target that exercises the MCP server error handling

## Testing
- cmake -S . -B build -G Ninja *(fails: missing LZ4 dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e20e6e40832896ec52b9293e1303